### PR TITLE
maxArray default value was not checked

### DIFF
--- a/prettyprint.js
+++ b/prettyprint.js
@@ -580,7 +580,7 @@ var prettyPrint = (function(){
 				}
 
 				util.forEach(arr, function(item,i){
-                    if (++count > settings.maxArray) {
+                    if (settings.maxArray >= 0 && ++count > settings.maxArray) {
                         table.addRow([
                             i + '..' + (arr.length-1),
                             typeDealer[ util.type(item) ]('...', depth+1, i)


### PR DESCRIPTION
maxArray is documented with an "infinite" default value, but the default value '-1' was not checked so the default behavior was actually to always compact arrays if maxArray was not overridden.
